### PR TITLE
Fixing Previous and Star operators

### DIFF
--- a/reelay/formal/ptl.py
+++ b/reelay/formal/ptl.py
@@ -143,10 +143,11 @@ class PastTLBuilder(PastTLVisitor):
         child = self.visit(ctx.child)
 
         state = BooleanState(
-            update=child.output, 
+            update=None,
             variable=self.meta['bnum']
             )
-        state.output=Pre(state)
+        state.update = PreviousUpdate(state, child.output)
+        state.output = PreviousOutput(state)
 
         self.meta['bnum'] += 1
         self.states.append(state)

--- a/reelay/formal/regexp.py
+++ b/reelay/formal/regexp.py
@@ -152,7 +152,7 @@ class RegExpBuilder(RegExpVisitor):
             name = 'Expr'
 
         self.meta['name'] = name
-        self.meta['output'] = ctx.output
+        self.meta['output'] = BooleanOr(ctx.output, ctx.nullable)
 
     def visitAtomList(self, ctx:RegExpParser.AtomListContext):
         uncomma = [child for child in ctx.children if child.getText() != ',']

--- a/reelay/machine/timed.py
+++ b/reelay/machine/timed.py
@@ -1,5 +1,11 @@
 from reelay.machine.common import *
 
+class PreviousUpdate(Expr):
+    """docstring for Atomic"""
+    def __init__(self, state, child):
+        super().__init__()
+        self.children = [Pre(state), child]
+
 class OnceUpdate(Expr):
     """docstring for Atomic"""
     def __init__(self, state, child):
@@ -17,6 +23,12 @@ class SinceUpdate(Expr):
     def __init__(self, state, left, right):
         super().__init__()
         self.children = [Pre(state), left, right]
+
+class PreviousOutput(Expr):
+    """docstring for Atomic"""
+    def __init__(self, state):
+        super().__init__()
+        self.children = [Pre(state)]
 
 class TemporalOutput(Expr):
     """docstring for Atomic"""

--- a/reelay/target/cpp.py
+++ b/reelay/target/cpp.py
@@ -126,9 +126,15 @@ class StructGenerator(Visitor):
         return "({} and {})".format(self.visit(obj.children[0]), self.visit(obj.children[1]))
         # return "{} = {};".format(obj.variable, self.visit(obj.update))
 
+    def visitPreviousUpdate(self, obj):
+        return "{}".format(self.visit(obj.children[1]))
+
     def visitSinceUpdate(self, obj):
         return "{} or ({} and {})".format(self.visit(obj.children[2]), self.visit(obj.children[1]), self.visit(obj.children[0]))
         # return "{} = {};".format(obj.variable, self.visit(obj.update))
+
+    def visitPreviousOutput(self, obj):
+        return "{}".format(self.visit(obj.children[0]))
 
     def visitTemporalOutput(self, obj):
         return "{}".format(self.visit(obj.children[0]))

--- a/reelay/target/cpp.py
+++ b/reelay/target/cpp.py
@@ -105,6 +105,12 @@ class StructGenerator(Visitor):
             str_args = [self.visit(c) for c in obj.args]
             return obj.name + '({})'.format(','.join(str_args))
 
+    def visitbool(self, obj):
+        if obj:
+            return "true"
+        else:
+            return "false"
+
     def visitBooleanNot(self, obj):
         return "not({})".format(self.visit(obj.children[0]))
 

--- a/scripts/reelay
+++ b/scripts/reelay
@@ -71,7 +71,7 @@ def main(argv):
 
     config_file = args.spec_file
     with open(config_file) as f:
-        cfg = yaml.load(f)
+        cfg = yaml.safe_load(f)
 
         try:
             name = cfg['name'] if args.name == None else args.name
@@ -189,6 +189,6 @@ if __name__ == '__main__':
 #     roll : "angular.y" 
 #     pitch: "angular.z"
 #     """ 
-#     cfg = yaml.load(document)
+#     cfg = yaml.safe_load(document)
 
 #     print(cfg['ros']['assign'])


### PR DESCRIPTION
This pull request implements the Previous operator and fixes the Star operator implementation.
Since a Star is skippable, no violation of a formula p* should be produced even if p never holds in a log.
Finally, using yaml.safe_load prevents a warning.